### PR TITLE
Fix Solaris Kstat2 vendor frequency (MHz vs Hz) — CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#3505](https://github.com/oshi/oshi/pull/3505): Fix the AIX FFM backend reading `perfstat_partition_config_t.processorMHz` at the wrong struct offset (344 instead of 340), which reported the processor's vendor frequency as unknown - [@dbwiddis](https://github.com/dbwiddis).
 * [#3507](https://github.com/oshi/oshi/pull/3507): Extend the native-free provider (`oshi-common` alone, no JNA or FFM) to NetBSD, so NetBSD users without the JNA native library can depend on `oshi-common` without `--enable-native-access`, as Linux already can - [@dbwiddis](https://github.com/dbwiddis).
 * [#3518](https://github.com/oshi/oshi/pull/3518): Consolidate the duplicated `sysctl` utility code into shared command-line (`BsdSysctlUtil`), JNA (`SysctlUtilJNA`), and FFM (`SysctlFFM`) helpers, and fix a latent bug where reading an int-width sysctl (e.g. FreeBSD `hw.clockrate`) through the `long` API returned uninitialized bytes, intermittently reporting an absurd CPU vendor frequency such as 6.2 EHz - [@dbwiddis](https://github.com/dbwiddis).
+* [#3519](https://github.com/oshi/oshi/pull/3519): Fix the Solaris JNA Kstat2 processor identifier reporting the CPU vendor frequency in MHz instead of Hz (missing the `clock_MHz` to Hz conversion applied on the other code paths) - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorJNA.java
@@ -79,7 +79,9 @@ final class SolarisCentralProcessorJNA extends SolarisCentralProcessor {
         String cpuFamily = results[2] == null ? "" : results[2].toString();
         String cpuModel = results[3] == null ? "" : results[3].toString();
         String cpuStepping = results[4] == null ? "" : results[4].toString();
-        long cpuFreq = results[5] == null ? 0L : (long) results[5];
+        // clock_MHz is in MHz; the ProcessorIdentifier vendor frequency contract is Hz (matches the non-Kstat2 path
+        // above and the FFM implementation).
+        long cpuFreq = results[5] == null ? 0L : (long) results[5] * 1_000_000L;
 
         String processorID = getProcessorID(cpuStepping, cpuModel, cpuFamily);
         return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,


### PR DESCRIPTION
Fork CI for the Solaris Kstat2 vendor-frequency fix (clock_MHz not converted to Hz), caught by the #3518 vendor/max frequency sanity test. NOTE: the reported failure was on Solaris SPARC; OSHI CI runs OpenIndiana x86, which may or may not exercise the same Kstat2 path.